### PR TITLE
minor naming fixes

### DIFF
--- a/pgns.xml
+++ b/pgns.xml
@@ -2303,7 +2303,7 @@
           <BitLength>16</BitLength>
           <Scale>0.001</Scale>
         </DblField>
-        <DblField Name="Offset">
+        <DblField Name="Range">
           <Description>Measurement range</Description>
           <BitOffset>56</BitOffset>
           <BitLength>8</BitLength>
@@ -7055,7 +7055,7 @@
       </Fields>
     </PGNDefn>
     <PGNDefn PGN="130311">
-      <Name>Environmental Parameters</Name>
+      <Name>Environmental Parameters Ext</Name>
       <ByteLength>8</ByteLength>
       <Fields>
         <UIntField Name="SID">

--- a/src/PGNs.cpp
+++ b/src/PGNs.cpp
@@ -2090,12 +2090,12 @@ WaterDepth WaterDepth::fromMessage(Message const& message) {
     int16_t offset_iraw =
         reinterpret_cast<int16_t const&>(offset_raw);
     result.offset = offset_iraw * 0.001 + 0.0;
-    auto offset1_raw = decode8(
+    auto range_raw = decode8(
         &message.payload[7]
     );
-    int8_t offset1_iraw =
-        reinterpret_cast<int8_t const&>(offset1_raw);
-    result.offset1 = offset1_iraw * 10.0 + 0.0;
+    int8_t range_iraw =
+        reinterpret_cast<int8_t const&>(range_raw);
+    result.range = range_iraw * 10.0 + 0.0;
     return result;
 }
 const int DistanceLog::BYTE_LENGTH;
@@ -5635,10 +5635,10 @@ EnvironmentalParameters EnvironmentalParameters::fromMessage(Message const& mess
     ) >> 0) & 0xff;
     return result;
 }
-const int EnvironmentalParameters1::BYTE_LENGTH;
-const int EnvironmentalParameters1::ID;
+const int EnvironmentalParametersExt::BYTE_LENGTH;
+const int EnvironmentalParametersExt::ID;
 
-EnvironmentalParameters1 EnvironmentalParameters1::fromMessage(Message const& message) {
+EnvironmentalParametersExt EnvironmentalParametersExt::fromMessage(Message const& message) {
     if (message.pgn != ID) {
         throw std::invalid_argument("unexpected PGN ID");
     }
@@ -5646,7 +5646,7 @@ EnvironmentalParameters1 EnvironmentalParameters1::fromMessage(Message const& me
         throw std::invalid_argument("unexpected payload size");
     }
 
-    EnvironmentalParameters1 result;
+    EnvironmentalParametersExt result;
     result.time = message.time;
 
     result.sid = (decode8(

--- a/src/PGNs.hpp
+++ b/src/PGNs.hpp
@@ -835,7 +835,7 @@ namespace nmea2000 {
             uint8_t sid;
             float depth;
             float offset;
-            float offset1;
+            float range;
         };
         struct DistanceLog {
             static const int BYTE_LENGTH = 14;
@@ -2060,11 +2060,11 @@ namespace nmea2000 {
             uint16_t atmospheric_pressure;
             uint8_t reserved;
         };
-        struct EnvironmentalParameters1 {
+        struct EnvironmentalParametersExt {
             static const int BYTE_LENGTH = 8;
             static const int ID = 130311;
 
-            static EnvironmentalParameters1 fromMessage(Message const& message);
+            static EnvironmentalParametersExt fromMessage(Message const& message);
 
             base::Time time;
 


### PR DESCRIPTION
Avoid name collision (to avoid having a 1/2/3/ suffix), and rename
'offset' to 'range' since the documentation says it's really a range