### PR TITLE
fix valgrind warnings in test suite

### DIFF
--- a/test/test_Message.cpp
+++ b/test/test_Message.cpp
@@ -9,7 +9,7 @@ struct MessageTest : public ::testing::Test {
 TEST_F(MessageTest, it_initializes_a_Message_from_a_CAN_frame_in_PDU1) {
     // Example taken from https://michael.chtoen.com/convert-j1939-id-to-pgn.php
     uint32_t id = 0x1CEC523D;
-    canbus::Message can;
+    auto can = canbus::Message::Zeroed();
     can.can_id = id;
     Message msg = Message::fromCAN(can);
     ASSERT_EQ(0b111, msg.priority);
@@ -20,7 +20,7 @@ TEST_F(MessageTest, it_initializes_a_Message_from_a_CAN_frame_in_PDU1) {
 
 TEST_F(MessageTest, it_initializes_a_Message_from_a_CAN_frame_in_PDU2) {
     uint32_t id = 0xFFE6CEE;
-    canbus::Message can;
+    auto can = canbus::Message::Zeroed();
     can.can_id = id;
     Message msg = Message::fromCAN(can);
 
@@ -32,7 +32,7 @@ TEST_F(MessageTest, it_initializes_a_Message_from_a_CAN_frame_in_PDU2) {
 }
 
 TEST_F(MessageTest, it_copies_the_package_time_data_and_length) {
-    canbus::Message can;
+    auto can = canbus::Message::Zeroed();
     can.can_id = 0x1234;
     can.time = base::Time::fromMilliseconds(1000);
     can.size = 5;

--- a/test/test_Receiver.cpp
+++ b/test/test_Receiver.cpp
@@ -21,21 +21,28 @@ struct ReceiverTest : public ::testing::Test {
         : library(knownPGNs)
         , receiver(library) {
     }
+
+    Message randomMessage(int size) {
+        Message msg;
+        msg.size = size;
+        for (int i = 0; i < size; ++i) {
+            msg.payload[i] = rand();
+        }
+        return msg;
+    }
 };
 
 TEST_F(ReceiverTest, it_returns_a_single_packet_PGN_right_away) {
-    Message message;
+    auto message = randomMessage(5);
     message.pgn = 1;
-    message.size = 5;
     auto result = receiver.process(message);
     ASSERT_EQ(Receiver::COMPLETE, result.first);
     ASSERT_EQ(message, result.second);
 }
 
 TEST_F(ReceiverTest, it_rejects_a_first_packet_whose_sequence_number_is_not_zero) {
-    Message message;
+    auto message = randomMessage(8);
     message.pgn = 3;
-    message.size = 8;
     message.payload[0] = 0xA1;
     message.payload[1] = 2;
     auto result = receiver.process(message);
@@ -137,7 +144,5 @@ TEST_F(ReceiverFastPacketReassemblyTest, it_truncates_the_last_message_size_to_t
     message.payload[9] = rand();
     auto result = receiver.process(message);
     ASSERT_EQ(Receiver::COMPLETE, result.first);
-    for (int i = 0; i < 3; ++i) {
-        ASSERT_NE(message.payload[7 + i], result.second.payload[12 + i]);
-    }
+    ASSERT_EQ(result.second.size, 12);
 }


### PR DESCRIPTION
The test suite was not initializing some fields, or relying on
non-initialized fields in tests. This made the test suite crash
every once in a while.