### PR TITLE
feat: add instance information to PGNs

### DIFF
--- a/codegen/lib/pgn_definitions/field.rb
+++ b/codegen/lib/pgn_definitions/field.rb
@@ -30,7 +30,7 @@ module PGNDefinitions
         end
 
         SUPPORTED_FIELD_TYPES = %w[
-            ASCIIField EnumField IntField UIntField DblField UDblField
+            ASCIIField EnumField IntField UIntField DblField UDblField InstanceField
         ].freeze
 
         def supported?
@@ -39,7 +39,7 @@ module PGNDefinitions
         end
 
         def integer?
-            %w[EnumField IntField UIntField].include?(@xml.name)
+            %w[EnumField IntField UIntField InstanceField].include?(@xml.name)
         end
 
         def float?
@@ -47,11 +47,15 @@ module PGNDefinitions
         end
 
         def unsigned?
-            @xml.name.start_with?('U') || enum?
+            @xml.name.start_with?('U') || enum? || instance_field?
         end
 
         def ascii?
             %w[ASCIIField].include?(@xml.name)
+        end
+
+        def instance_field?
+            @xml.name == "InstanceField"
         end
 
         def enum?

--- a/src/PGNs.cpp
+++ b/src/PGNs.cpp
@@ -69,12 +69,21 @@ ISOAddressClaim ISOAddressClaim::fromMessage(Message const& message) {
     ISOAddressClaim result;
     result.time = message.time;
 
+    result.device_instance_lower = (decode8(
+        &message.payload[4]
+    ) >> 0) & 0x7;
+    result.device_instance_upper = (decode8(
+        &message.payload[4]
+    ) >> 3) & 0x1f;
     result.device_function = (decode8(
         &message.payload[5]
     ) >> 0) & 0xff;
     result.device_class = (decode8(
         &message.payload[6]
     ) >> 1) & 0x7f;
+    result.system_instance = (decode8(
+        &message.payload[7]
+    ) >> 0) & 0xf;
     result.industry_group = (decode8(
         &message.payload[7]
     ) >> 4) & 0x7;
@@ -100,6 +109,12 @@ ISOCommandedAddress ISOCommandedAddress::fromMessage(Message const& message) {
     result.manufacturer_code = (decode16(
         &message.payload[2]
     ) >> 5) & 0x7ff;
+    result.device_instance_lower = (decode8(
+        &message.payload[4]
+    ) >> 0) & 0x7;
+    result.device_instance_upper = (decode8(
+        &message.payload[4]
+    ) >> 3) & 0x1f;
     result.device_function = (decode8(
         &message.payload[5]
     ) >> 0) & 0xff;
@@ -109,6 +124,9 @@ ISOCommandedAddress ISOCommandedAddress::fromMessage(Message const& message) {
     result.device_class = (decode8(
         &message.payload[6]
     ) >> 1) & 0x7f;
+    result.system_instance = (decode8(
+        &message.payload[7]
+    ) >> 0) & 0xf;
     result.industry_code = (decode8(
         &message.payload[7]
     ) >> 4) & 0x7;
@@ -165,6 +183,9 @@ LowranceTemperature LowranceTemperature::fromMessage(Message const& message) {
     result.industry_code = (decode8(
         &message.payload[1]
     ) >> 5) & 0x7;
+    result.temperature_instance = (decode8(
+        &message.payload[2]
+    ) >> 0) & 0xf;
     result.temperature_source = (decode8(
         &message.payload[2]
     ) >> 4) & 0xf;
@@ -1107,6 +1128,9 @@ Rudder Rudder::fromMessage(Message const& message) {
     Rudder result;
     result.time = message.time;
 
+    result.instance = (decode8(
+        &message.payload[0]
+    ) >> 0) & 0xff;
     result.direction_order = (decode8(
         &message.payload[1]
     ) >> 0) & 0x7;
@@ -1277,6 +1301,9 @@ EngineParametersRapidUpdate EngineParametersRapidUpdate::fromMessage(Message con
     EngineParametersRapidUpdate result;
     result.time = message.time;
 
+    result.engine_instance = (decode8(
+        &message.payload[0]
+    ) >> 0) & 0xff;
     auto engine_speed_raw = decode16(
         &message.payload[1]
     );
@@ -1311,6 +1338,9 @@ EngineParametersDynamic EngineParametersDynamic::fromMessage(Message const& mess
     EngineParametersDynamic result;
     result.time = message.time;
 
+    result.engine_instance = (decode8(
+        &message.payload[0]
+    ) >> 0) & 0xff;
     result.oil_pressure = (decode16(
         &message.payload[1]
     ) >> 0) & 0xffff;
@@ -1390,6 +1420,9 @@ TransmissionParametersDynamic TransmissionParametersDynamic::fromMessage(Message
     TransmissionParametersDynamic result;
     result.time = message.time;
 
+    result.engine_instance = (decode8(
+        &message.payload[0]
+    ) >> 0) & 0xff;
     result.transmission_gear = (decode8(
         &message.payload[1]
     ) >> 0) & 0x3;
@@ -1464,6 +1497,9 @@ TripParametersEngine TripParametersEngine::fromMessage(Message const& message) {
     TripParametersEngine result;
     result.time = message.time;
 
+    result.engine_instance = (decode8(
+        &message.payload[0]
+    ) >> 0) & 0xff;
     result.trip_fuel_used = (decode16(
         &message.payload[1]
     ) >> 0) & 0xffff;
@@ -1501,6 +1537,9 @@ EngineParametersStatic EngineParametersStatic::fromMessage(Message const& messag
     EngineParametersStatic result;
     result.time = message.time;
 
+    result.engine_instance = (decode8(
+        &message.payload[0]
+    ) >> 0) & 0xff;
     result.rated_engine_speed = (decode16(
         &message.payload[1]
     ) >> 0) & 0xffff;
@@ -1526,6 +1565,9 @@ BinarySwitchBankStatus BinarySwitchBankStatus::fromMessage(Message const& messag
     BinarySwitchBankStatus result;
     result.time = message.time;
 
+    result.indicator_bank_instance = (decode8(
+        &message.payload[0]
+    ) >> 0) & 0xff;
     result.indicator = (decode8(
         &message.payload[1]
     ) >> 0) & 0x3;
@@ -1545,6 +1587,9 @@ SwitchBankControl SwitchBankControl::fromMessage(Message const& message) {
     SwitchBankControl result;
     result.time = message.time;
 
+    result.switch_bank_instance = (decode8(
+        &message.payload[0]
+    ) >> 0) & 0xff;
     result.switch_state = (decode8(
         &message.payload[1]
     ) >> 0) & 0x3;
@@ -1564,6 +1609,9 @@ ACInputStatus ACInputStatus::fromMessage(Message const& message) {
     ACInputStatus result;
     result.time = message.time;
 
+    result.ac_instance = (decode8(
+        &message.payload[0]
+    ) >> 0) & 0xff;
     result.number_of_lines = (decode8(
         &message.payload[1]
     ) >> 0) & 0xff;
@@ -1634,6 +1682,9 @@ ACOutputStatus ACOutputStatus::fromMessage(Message const& message) {
     ACOutputStatus result;
     result.time = message.time;
 
+    result.ac_instance = (decode8(
+        &message.payload[0]
+    ) >> 0) & 0xff;
     result.number_of_lines = (decode8(
         &message.payload[1]
     ) >> 0) & 0xff;
@@ -1704,6 +1755,9 @@ FluidLevel FluidLevel::fromMessage(Message const& message) {
     FluidLevel result;
     result.time = message.time;
 
+    result.instance = (decode8(
+        &message.payload[0]
+    ) >> 0) & 0xf;
     result.type = (decode8(
         &message.payload[0]
     ) >> 4) & 0xf;
@@ -1741,6 +1795,9 @@ DCDetailedStatus DCDetailedStatus::fromMessage(Message const& message) {
     result.sid = (decode8(
         &message.payload[0]
     ) >> 0) & 0xff;
+    result.dc_instance = (decode8(
+        &message.payload[1]
+    ) >> 0) & 0xff;
     result.dc_type = (decode8(
         &message.payload[2]
     ) >> 0) & 0xff;
@@ -1775,6 +1832,12 @@ ChargerStatus ChargerStatus::fromMessage(Message const& message) {
     ChargerStatus result;
     result.time = message.time;
 
+    result.charger_instance = (decode8(
+        &message.payload[0]
+    ) >> 0) & 0xff;
+    result.battery_instance = (decode8(
+        &message.payload[1]
+    ) >> 0) & 0xff;
     result.operating_state = (decode8(
         &message.payload[2]
     ) >> 0) & 0xff;
@@ -1809,6 +1872,9 @@ BatteryStatus BatteryStatus::fromMessage(Message const& message) {
     BatteryStatus result;
     result.time = message.time;
 
+    result.battery_instance = (decode8(
+        &message.payload[0]
+    ) >> 0) & 0xff;
     auto voltage_raw = decode16(
         &message.payload[1]
     );
@@ -1846,6 +1912,15 @@ InverterStatus InverterStatus::fromMessage(Message const& message) {
     InverterStatus result;
     result.time = message.time;
 
+    result.inverter_instance = (decode8(
+        &message.payload[0]
+    ) >> 0) & 0xff;
+    result.ac_instance = (decode8(
+        &message.payload[1]
+    ) >> 0) & 0xff;
+    result.dc_instance = (decode8(
+        &message.payload[2]
+    ) >> 0) & 0xff;
     result.operating_state = (decode8(
         &message.payload[3]
     ) >> 0) & 0xf;
@@ -1868,6 +1943,12 @@ ChargerConfigurationStatus ChargerConfigurationStatus::fromMessage(Message const
     ChargerConfigurationStatus result;
     result.time = message.time;
 
+    result.charger_instance = (decode8(
+        &message.payload[0]
+    ) >> 0) & 0xff;
+    result.battery_instance = (decode8(
+        &message.payload[1]
+    ) >> 0) & 0xff;
     result.charger_enable_disable = (decode8(
         &message.payload[2]
     ) >> 0) & 0x3;
@@ -1917,6 +1998,15 @@ InverterConfigurationStatus InverterConfigurationStatus::fromMessage(Message con
     InverterConfigurationStatus result;
     result.time = message.time;
 
+    result.inverter_instance = (decode8(
+        &message.payload[0]
+    ) >> 0) & 0xff;
+    result.ac_instance = (decode8(
+        &message.payload[1]
+    ) >> 0) & 0xff;
+    result.dc_instance = (decode8(
+        &message.payload[2]
+    ) >> 0) & 0xff;
     result.inverter_enable_disable = (decode8(
         &message.payload[3]
     ) >> 0) & 0x3;
@@ -1948,6 +2038,12 @@ AGSConfigurationStatus AGSConfigurationStatus::fromMessage(Message const& messag
     AGSConfigurationStatus result;
     result.time = message.time;
 
+    result.ags_instance = (decode8(
+        &message.payload[0]
+    ) >> 0) & 0xff;
+    result.generator_instance = (decode8(
+        &message.payload[1]
+    ) >> 0) & 0xff;
     result.ags_mode = (decode8(
         &message.payload[2]
     ) >> 0) & 0xff;
@@ -1967,6 +2063,9 @@ BatteryConfigurationStatus BatteryConfigurationStatus::fromMessage(Message const
     BatteryConfigurationStatus result;
     result.time = message.time;
 
+    result.battery_instance = (decode8(
+        &message.payload[0]
+    ) >> 0) & 0xff;
     result.battery_type = (decode8(
         &message.payload[1]
     ) >> 0) & 0xf;
@@ -2010,6 +2109,12 @@ AGSStatus AGSStatus::fromMessage(Message const& message) {
     AGSStatus result;
     result.time = message.time;
 
+    result.ags_instance = (decode8(
+        &message.payload[0]
+    ) >> 0) & 0xff;
+    result.generator_instance = (decode8(
+        &message.payload[1]
+    ) >> 0) & 0xff;
     result.ags_operating_state = (decode8(
         &message.payload[2]
     ) >> 0) & 0xff;
@@ -5692,6 +5797,9 @@ Temperature Temperature::fromMessage(Message const& message) {
     result.sid = (decode8(
         &message.payload[0]
     ) >> 0) & 0xff;
+    result.temperature_instance = (decode8(
+        &message.payload[1]
+    ) >> 0) & 0xff;
     result.temperature_source = (decode8(
         &message.payload[2]
     ) >> 0) & 0xff;
@@ -5729,6 +5837,9 @@ Humidity Humidity::fromMessage(Message const& message) {
     result.sid = (decode8(
         &message.payload[0]
     ) >> 0) & 0xff;
+    result.humidity_instance = (decode8(
+        &message.payload[1]
+    ) >> 0) & 0xff;
     result.humidity_source = (decode8(
         &message.payload[2]
     ) >> 0) & 0xff;
@@ -5760,6 +5871,9 @@ ActualPressure ActualPressure::fromMessage(Message const& message) {
     result.sid = (decode8(
         &message.payload[0]
     ) >> 0) & 0xff;
+    result.pressure_instance = (decode8(
+        &message.payload[1]
+    ) >> 0) & 0xff;
     result.pressure_source = (decode8(
         &message.payload[2]
     ) >> 0) & 0xff;
@@ -5788,6 +5902,9 @@ SetPressure SetPressure::fromMessage(Message const& message) {
     result.sid = (decode8(
         &message.payload[0]
     ) >> 0) & 0xff;
+    result.pressure_instance = (decode8(
+        &message.payload[1]
+    ) >> 0) & 0xff;
     result.pressure_source = (decode8(
         &message.payload[2]
     ) >> 0) & 0xff;
@@ -5812,6 +5929,9 @@ TemperatureExtendedRange TemperatureExtendedRange::fromMessage(Message const& me
 
     result.sid = (decode8(
         &message.payload[0]
+    ) >> 0) & 0xff;
+    result.temperature_instance = (decode8(
+        &message.payload[1]
     ) >> 0) & 0xff;
     result.temperature_source = (decode8(
         &message.payload[2]
@@ -6652,6 +6772,9 @@ SimnetFluidLevelSensorConfiguration SimnetFluidLevelSensorConfiguration::fromMes
     result.device = reinterpret_cast<int8_t const&>(
         device_raw
     );
+    result.instance = (decode8(
+        &message.payload[4]
+    ) >> 0) & 0xff;
     result.f = (decode8(
         &message.payload[5]
     ) >> 0) & 0xf;

--- a/src/PGNs.hpp
+++ b/src/PGNs.hpp
@@ -44,8 +44,11 @@ namespace nmea2000 {
 
             base::Time time;
 
+            uint8_t device_instance_lower;
+            uint8_t device_instance_upper;
             uint8_t device_function;
             uint8_t device_class;
+            uint8_t system_instance;
             uint8_t industry_group;
             uint8_t iso_self_configurable;
         };
@@ -58,9 +61,12 @@ namespace nmea2000 {
             base::Time time;
 
             uint16_t manufacturer_code;
+            uint8_t device_instance_lower;
+            uint8_t device_instance_upper;
             uint8_t device_function;
             uint8_t reserved;
             uint8_t device_class;
+            uint8_t system_instance;
             uint8_t industry_code;
             uint8_t iso_self_configurable;
             uint8_t new_source_address;
@@ -87,6 +93,7 @@ namespace nmea2000 {
 
             uint8_t reserved;
             uint8_t industry_code;
+            uint8_t temperature_instance;
             uint8_t temperature_source;
             float actual_temperature;
         };
@@ -466,6 +473,7 @@ namespace nmea2000 {
 
             base::Time time;
 
+            uint8_t instance;
             uint8_t direction_order;
             float angle_order;
             float position;
@@ -531,6 +539,7 @@ namespace nmea2000 {
 
             base::Time time;
 
+            uint8_t engine_instance;
             float engine_speed;
             uint16_t engine_boost_pressure;
             int8_t engine_tilt_trim;
@@ -544,6 +553,7 @@ namespace nmea2000 {
 
             base::Time time;
 
+            uint8_t engine_instance;
             uint16_t oil_pressure;
             float oil_temperature;
             float temperature;
@@ -566,6 +576,7 @@ namespace nmea2000 {
 
             base::Time time;
 
+            uint8_t engine_instance;
             uint8_t transmission_gear;
             uint8_t reserved;
             uint16_t oil_pressure;
@@ -593,6 +604,7 @@ namespace nmea2000 {
 
             base::Time time;
 
+            uint8_t engine_instance;
             uint16_t trip_fuel_used;
             float fuel_rate_average;
             float fuel_rate_economy;
@@ -606,6 +618,7 @@ namespace nmea2000 {
 
             base::Time time;
 
+            uint8_t engine_instance;
             uint16_t rated_engine_speed;
             uint8_t vin;
             uint16_t software_id;
@@ -618,6 +631,7 @@ namespace nmea2000 {
 
             base::Time time;
 
+            uint8_t indicator_bank_instance;
             uint8_t indicator;
         };
         struct SwitchBankControl {
@@ -628,6 +642,7 @@ namespace nmea2000 {
 
             base::Time time;
 
+            uint8_t switch_bank_instance;
             uint8_t switch_state;
         };
         struct ACInputStatus {
@@ -638,6 +653,7 @@ namespace nmea2000 {
 
             base::Time time;
 
+            uint8_t ac_instance;
             uint8_t number_of_lines;
             uint8_t line;
             uint8_t acceptability;
@@ -658,6 +674,7 @@ namespace nmea2000 {
 
             base::Time time;
 
+            uint8_t ac_instance;
             uint8_t number_of_lines;
             uint8_t line;
             uint8_t waveform;
@@ -678,6 +695,7 @@ namespace nmea2000 {
 
             base::Time time;
 
+            uint8_t instance;
             uint8_t type;
             float level;
             float capacity;
@@ -692,6 +710,7 @@ namespace nmea2000 {
             base::Time time;
 
             uint8_t sid;
+            uint8_t dc_instance;
             uint8_t dc_type;
             uint8_t state_of_charge;
             uint8_t state_of_health;
@@ -706,6 +725,8 @@ namespace nmea2000 {
 
             base::Time time;
 
+            uint8_t charger_instance;
+            uint8_t battery_instance;
             uint8_t operating_state;
             uint8_t charge_mode;
             uint8_t charger_enable_disable;
@@ -721,6 +742,7 @@ namespace nmea2000 {
 
             base::Time time;
 
+            uint8_t battery_instance;
             float voltage;
             float current;
             float temperature;
@@ -734,6 +756,9 @@ namespace nmea2000 {
 
             base::Time time;
 
+            uint8_t inverter_instance;
+            uint8_t ac_instance;
+            uint8_t dc_instance;
             uint8_t operating_state;
             uint8_t inverter;
         };
@@ -745,6 +770,8 @@ namespace nmea2000 {
 
             base::Time time;
 
+            uint8_t charger_instance;
+            uint8_t battery_instance;
             uint8_t charger_enable_disable;
             uint8_t reserved;
             float charge_current_limit;
@@ -763,6 +790,9 @@ namespace nmea2000 {
 
             base::Time time;
 
+            uint8_t inverter_instance;
+            uint8_t ac_instance;
+            uint8_t dc_instance;
             uint8_t inverter_enable_disable;
             uint8_t inverter_mode;
             uint8_t load_sense_enable_disable;
@@ -777,6 +807,8 @@ namespace nmea2000 {
 
             base::Time time;
 
+            uint8_t ags_instance;
+            uint8_t generator_instance;
             uint8_t ags_mode;
         };
         struct BatteryConfigurationStatus {
@@ -787,6 +819,7 @@ namespace nmea2000 {
 
             base::Time time;
 
+            uint8_t battery_instance;
             uint8_t battery_type;
             uint8_t supports_equalization;
             uint8_t reserved;
@@ -805,6 +838,8 @@ namespace nmea2000 {
 
             base::Time time;
 
+            uint8_t ags_instance;
+            uint8_t generator_instance;
             uint8_t ags_operating_state;
             uint8_t generator_state;
             uint8_t generator_on_reason;
@@ -2084,6 +2119,7 @@ namespace nmea2000 {
             base::Time time;
 
             uint8_t sid;
+            uint8_t temperature_instance;
             uint8_t temperature_source;
             float actual_temperature;
             float set_temperature;
@@ -2098,6 +2134,7 @@ namespace nmea2000 {
             base::Time time;
 
             uint8_t sid;
+            uint8_t humidity_instance;
             uint8_t humidity_source;
             uint16_t actual_humidity;
             uint16_t set_humidity;
@@ -2112,6 +2149,7 @@ namespace nmea2000 {
             base::Time time;
 
             uint8_t sid;
+            uint8_t pressure_instance;
             uint8_t pressure_source;
             float pressure;
         };
@@ -2124,6 +2162,7 @@ namespace nmea2000 {
             base::Time time;
 
             uint8_t sid;
+            uint8_t pressure_instance;
             uint8_t pressure_source;
             uint32_t set_pressure;
         };
@@ -2136,6 +2175,7 @@ namespace nmea2000 {
             base::Time time;
 
             uint8_t sid;
+            uint8_t temperature_instance;
             uint8_t temperature_source;
             float actual_temperature;
             float set_temperature;
@@ -2440,6 +2480,7 @@ namespace nmea2000 {
             uint8_t industry_code;
             uint8_t c;
             int8_t device;
+            uint8_t instance;
             uint8_t f;
             uint8_t tank_type;
             float capacity;


### PR DESCRIPTION
# What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->
Add reading support for the instance information for all PGNs inside the codegen that generates the cpp and hpp
for the PGNs according to a given xml file.

# Checklist
- [x] Assign yourself  in the PR
- [ ] Write unit tests (when relevant)
- [x] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
