### PR TITLE
feat: support fast packet transmission

### DIFF
--- a/src/Adapters.cpp
+++ b/src/Adapters.cpp
@@ -35,12 +35,11 @@ CAN::~CAN() {
     delete m_driver;
 }
 
-void CAN::writeMessage(Message const& message) {
-    if (message.size > 8) {
-        throw Unsupported("writing to CAN does not suoport fast packet messages");
+void CAN::writeMessage(Message const& message)
+{
+    for (auto const& can_msg : message.toCAN()) {
+        m_driver->write(can_msg);
     }
-
-    m_driver->write(message.toCAN());
 }
 
 struct CANReadTimeoutGuard {

--- a/src/Message.cpp
+++ b/src/Message.cpp
@@ -44,7 +44,69 @@ bool Message::fastPacket() const
     return size > MAX_CAN_PAYLOAD_SIZE;
 }
 
-Message Message::fromCAN(canbus::Message const& can) {
+std::vector<canbus::Message> Message::fastPacketFrames() const
+{
+    if (size <= MAX_CAN_PAYLOAD_SIZE || size > MAX_PAYLOAD_LENGTH) {
+        throw "Fast packet messages size must be grater than 8 bytes";
+    }
+
+    const uint8_t num_msgs =
+        1 + std::ceil(static_cast<float>(size - FAST_PACKET_FIRST_PAYLOAD_LENGTH) /
+                      FAST_PACKET_SUBSEQUENT_PAYLOAD_LENGTH);
+    std::vector<canbus::Message> msgs(num_msgs);
+
+    const uint8_t seq_num = fastPacketSequenceNumber();
+    uint8_t frame_count{0};
+    uint8_t const* it = (uint8_t*)(&payload);
+    {
+        canbus::Message& msg0 = msgs[frame_count];
+
+        msg0.data[0] = (seq_num << 5) | frame_count;
+        msg0.data[1] = size;
+        std::copy(it,
+            (it + FAST_PACKET_FIRST_PAYLOAD_LENGTH),
+            ((uint8_t*)&msg0.data) + 2);
+
+        it += FAST_PACKET_FIRST_PAYLOAD_LENGTH;
+        frame_count++;
+    }
+
+    while (frame_count < num_msgs - 1) {
+        canbus::Message& msg = msgs[frame_count];
+
+        msg.data[0] = (seq_num << 5) | frame_count;
+        std::copy(it,
+            it + FAST_PACKET_SUBSEQUENT_PAYLOAD_LENGTH,
+            ((uint8_t*)&msg.data) + 1);
+
+        it += FAST_PACKET_SUBSEQUENT_PAYLOAD_LENGTH;
+        frame_count++;
+    }
+
+    const uint8_t last_message_payload_size = size - (it - (uint8_t*)&payload);
+    {
+        canbus::Message& last = msgs[frame_count];
+        last.data[0] = (seq_num << 5) | frame_count;
+        std::copy(it, it + last_message_payload_size, ((uint8_t*)&last.data) + 1);
+    }
+
+    for (auto& msg : msgs) {
+        msg.size = MAX_CAN_PAYLOAD_SIZE;
+    }
+    msgs.back().size = last_message_payload_size + 1;
+
+    return msgs;
+}
+
+std::uint8_t Message::fastPacketSequenceNumber()
+{
+    static uint8_t seq{0xff};
+    seq = (seq + 1) % 8;
+    return seq;
+}
+
+Message Message::fromCAN(canbus::Message const& can)
+{
     Message n2k;
 
     n2k.time = can.time;

--- a/src/Message.cpp
+++ b/src/Message.cpp
@@ -1,26 +1,47 @@
-#include <nmea2000/Message.hpp>
+#include <canbus/Message.hpp>
+#include <cmath>
 #include <cstring>
+#include <nmea2000/Message.hpp>
 
 using namespace nmea2000;
 
-canbus::Message Message::toCAN() const {
-    canbus::Message can;
+std::vector<canbus::Message> Message::toCAN() const
+{
+    std::vector<canbus::Message> msgs(0);
+    if (fastPacket()) {
+        msgs = fastPacketFrames();
+    }
+    else {
+        canbus::Message can;
+        can.size = size;
+        std::memcpy(can.data, payload, size);
+        msgs = {can};
+    }
 
-    can.time = time;
-    can.size = size;
-    std::memcpy(can.data, payload, size);
+    const uint32_t can_id = canID();
+    for (auto& can : msgs) {
+        can.time = time;
+        can.can_id = can_id;
+    }
 
-    uint32_t can_id =
-        source |
-        (priority & 0x7) << 26 |
-        pgn << 8;
+    return msgs;
+}
+
+uint32_t Message::canID() const
+{
+    uint32_t can_id = source | (priority & 0x7) << 26 | pgn << 8;
 
     bool pdu2 = 0xF000 == (pgn & 0xF000);
     if (!pdu2) {
         can_id |= (static_cast<uint32_t>(destination) << 8);
     }
-    can.can_id = can_id | canbus::FLAG_EXTENDED_FRAME;
-    return can;
+
+    return can_id | canbus::FLAG_EXTENDED_FRAME;
+}
+
+bool Message::fastPacket() const
+{
+    return size > MAX_CAN_PAYLOAD_SIZE;
 }
 
 Message Message::fromCAN(canbus::Message const& can) {

--- a/src/Message.cpp
+++ b/src/Message.cpp
@@ -51,50 +51,34 @@ std::vector<canbus::Message> Message::fastPacketFrames() const
         throw "Fast packet messages size must be grater than 8 bytes";
     }
 
-    const uint8_t num_msgs =
-        1 + std::ceil(static_cast<float>(size - FAST_PACKET_FIRST_PAYLOAD_LENGTH) /
-                      FAST_PACKET_SUBSEQUENT_PAYLOAD_LENGTH);
-    std::vector<canbus::Message> msgs(num_msgs);
+    const uint8_t subsequent_size = size - FAST_PACKET_FIRST_PAYLOAD_LENGTH;
+    const uint8_t subsequent_msgs =
+        (subsequent_size + FAST_PACKET_SUBSEQUENT_PAYLOAD_LENGTH - 1) /
+        FAST_PACKET_SUBSEQUENT_PAYLOAD_LENGTH;
+    std::vector<canbus::Message> msgs(1 + subsequent_msgs);
 
     const uint8_t seq_num = fastPacketSequenceNumber();
-    uint8_t frame_count{0};
-    uint8_t const* it = (uint8_t*)(&payload);
-    {
-        canbus::Message& msg0 = msgs[frame_count];
-
-        msg0.data[0] = (seq_num << 5) | frame_count;
+    { // 0th frame
+        canbus::Message& msg0 = msgs[0];
+        msg0.data[0] = (seq_num << 5);
         msg0.data[1] = size;
-        std::copy(it,
-            (it + FAST_PACKET_FIRST_PAYLOAD_LENGTH),
-            ((uint8_t*)&msg0.data) + 2);
-
-        it += FAST_PACKET_FIRST_PAYLOAD_LENGTH;
-        frame_count++;
+        std::copy(payload, (payload + FAST_PACKET_FIRST_PAYLOAD_LENGTH), msg0.data + 2);
+        msg0.size = 8;
     }
 
-    while (frame_count < num_msgs - 1) {
-        canbus::Message& msg = msgs[frame_count];
+    uint8_t const* subsequent_payload = payload + FAST_PACKET_FIRST_PAYLOAD_LENGTH;
+    for (uint8_t i = 0; i < subsequent_msgs; i++) {
+        canbus::Message& msg = msgs[i + 1];
+        msg.data[0] = (seq_num << 5) | (i + 1);
 
-        msg.data[0] = (seq_num << 5) | frame_count;
-        std::copy(it,
-            it + FAST_PACKET_SUBSEQUENT_PAYLOAD_LENGTH,
-            ((uint8_t*)&msg.data) + 1);
-
-        it += FAST_PACKET_SUBSEQUENT_PAYLOAD_LENGTH;
-        frame_count++;
+        const uint8_t n = FAST_PACKET_SUBSEQUENT_PAYLOAD_LENGTH;
+        const uint8_t offset = i * n;
+        const uint8_t this_payload_size = std::min<uint8_t>(n, subsequent_size - offset);
+        std::copy(subsequent_payload + offset,
+            subsequent_payload + offset + this_payload_size,
+            msg.data + 1);
+        msg.size = this_payload_size + 1;
     }
-
-    const uint8_t last_message_payload_size = size - (it - (uint8_t*)&payload);
-    {
-        canbus::Message& last = msgs[frame_count];
-        last.data[0] = (seq_num << 5) | frame_count;
-        std::copy(it, it + last_message_payload_size, ((uint8_t*)&last.data) + 1);
-    }
-
-    for (auto& msg : msgs) {
-        msg.size = MAX_CAN_PAYLOAD_SIZE;
-    }
-    msgs.back().size = last_message_payload_size + 1;
 
     return msgs;
 }

--- a/src/Message.cpp
+++ b/src/Message.cpp
@@ -49,7 +49,7 @@ std::vector<canbus::Message> Message::fastPacketFrames() const
 {
     if (size <= MAX_CAN_PAYLOAD_SIZE || size > MAX_PAYLOAD_LENGTH) {
         throw std::invalid_argument(
-            "Fast packet messages size must be grater than 8 bytes");
+            "Fast packet messages must have (8, 223] size");
     }
 
     const uint8_t subsequent_size = size - FAST_PACKET_FIRST_PAYLOAD_LENGTH;

--- a/src/Message.cpp
+++ b/src/Message.cpp
@@ -1,3 +1,4 @@
+#include <atomic>
 #include <canbus/Message.hpp>
 #include <cmath>
 #include <cstring>
@@ -100,9 +101,8 @@ std::vector<canbus::Message> Message::fastPacketFrames() const
 
 std::uint8_t Message::fastPacketSequenceNumber()
 {
-    static uint8_t seq{0xff};
-    seq = (seq + 1) % 8;
-    return seq;
+    static std::atomic<uint8_t> seq{0};
+    return (seq++) % 8;
 }
 
 Message Message::fromCAN(canbus::Message const& can)

--- a/src/Message.cpp
+++ b/src/Message.cpp
@@ -48,7 +48,8 @@ bool Message::fastPacket() const
 std::vector<canbus::Message> Message::fastPacketFrames() const
 {
     if (size <= MAX_CAN_PAYLOAD_SIZE || size > MAX_PAYLOAD_LENGTH) {
-        throw "Fast packet messages size must be grater than 8 bytes";
+        throw std::invalid_argument(
+            "Fast packet messages size must be grater than 8 bytes");
     }
 
     const uint8_t subsequent_size = size - FAST_PACKET_FIRST_PAYLOAD_LENGTH;

--- a/src/Message.hpp
+++ b/src/Message.hpp
@@ -10,6 +10,8 @@ namespace nmea2000 {
         static const int MAX_PAYLOAD_LENGTH = 223; // with fast packet
         static const int NO_DESTINATION = 0xFF;    // with fast packet
         static constexpr uint8_t MAX_CAN_PAYLOAD_SIZE{8};
+        static constexpr uint8_t FAST_PACKET_FIRST_PAYLOAD_LENGTH{6};
+        static constexpr uint8_t FAST_PACKET_SUBSEQUENT_PAYLOAD_LENGTH{7};
 
         base::Time time;
 
@@ -29,6 +31,7 @@ namespace nmea2000 {
 
     private:
         std::vector<canbus::Message> fastPacketFrames() const;
+        static std::uint8_t fastPacketSequenceNumber();
     };
 }
 

--- a/src/Message.hpp
+++ b/src/Message.hpp
@@ -8,7 +8,8 @@ namespace nmea2000 {
     /** A NMEA2000 message */
     struct Message {
         static const int MAX_PAYLOAD_LENGTH = 223; // with fast packet
-        static const int NO_DESTINATION = 0xFF; // with fast packet
+        static const int NO_DESTINATION = 0xFF;    // with fast packet
+        static constexpr uint8_t MAX_CAN_PAYLOAD_SIZE{8};
 
         base::Time time;
 
@@ -19,10 +20,15 @@ namespace nmea2000 {
         uint8_t size = 0;
         uint8_t payload[MAX_PAYLOAD_LENGTH];
 
-        canbus::Message toCAN() const;
+        uint32_t canID() const;
+        std::vector<canbus::Message> toCAN() const;
         static Message fromCAN(canbus::Message const& can);
 
-        bool operator == (Message const& other) const;
+        bool operator==(Message const& other) const;
+        bool fastPacket() const;
+
+    private:
+        std::vector<canbus::Message> fastPacketFrames() const;
     };
 }
 

--- a/src/Message.hpp
+++ b/src/Message.hpp
@@ -29,9 +29,16 @@ namespace nmea2000 {
         bool operator==(Message const& other) const;
         bool fastPacket() const;
 
+        /**
+         *  sequence number generation for fast packet messages
+         *
+         * it is public for testing purposes only, the user shouldn't need to ever
+         * call this
+         */
+        static std::uint8_t fastPacketSequenceNumber();
+
     private:
         std::vector<canbus::Message> fastPacketFrames() const;
-        static std::uint8_t fastPacketSequenceNumber();
     };
 }
 

--- a/test/test_CANWithReceiver.cpp
+++ b/test/test_CANWithReceiver.cpp
@@ -47,7 +47,9 @@ TEST_F(CANWithReceiverTest, it_decodes_a_fluid_level_message_from_CAN) {
 }
 
 TEST_F(CANWithReceiverTest, it_returns_an_address_claim_query) {
-    auto can = receiver.queryAddressClaim().toCAN();
+    auto to_can = receiver.queryAddressClaim().toCAN();
+    ASSERT_EQ(1, to_can.size());
+    canbus::Message& can = to_can.at(0);
     auto expected = makeCANMessage(0x1CEAFF00, { 0, 0xee, 0 });
     ASSERT_EQ(can.can_id, expected.can_id);
     ASSERT_EQ(can.size, expected.size);
@@ -56,7 +58,9 @@ TEST_F(CANWithReceiverTest, it_returns_an_address_claim_query) {
 }
 
 TEST_F(CANWithReceiverTest, it_returns_a_product_information_query) {
-    auto can = receiver.queryProductInformation(144).toCAN();
+    auto to_can = receiver.queryProductInformation(144).toCAN();
+    ASSERT_EQ(1, to_can.size());
+    canbus::Message& can = to_can.at(0);
     auto expected = makeCANMessage(0x1CEA9000, { 0x14, 0xf0, 0x1 });
     ASSERT_EQ(can.can_id, expected.can_id);
     ASSERT_EQ(can.size, expected.size);

--- a/test/test_Message.cpp
+++ b/test/test_Message.cpp
@@ -141,7 +141,7 @@ TEST_F(MessageTest, it_increments_the_sequence_number)
 
     uint8_t payload[] = "first1second2third3";
     msg.size = sizeof(payload) - 1; // -1 -> do not copy '/0'
-    std::copy((char*)&payload, (char*)&payload + msg.size, msg.payload);
+    std::copy(payload, payload + msg.size, msg.payload);
 
     auto first = msg.toCAN();
     EXPECT_EQ(first.at(0).data[0] >> 5, first.at(1).data[0] >> 5);

--- a/test/test_Message.cpp
+++ b/test/test_Message.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include <nmea2000/Message.hpp>
 #include <nmea2000/Receiver.hpp>
+#include <thread>
 
 using namespace nmea2000;
 
@@ -123,13 +124,13 @@ TEST_F(MessageTest, it_produces_fast_packet_messages)
     });
 
     Receiver recv(lib);
-    auto[s0, m0] = recv.process(Message::fromCAN(can.at(0)));
+    auto [s0, m0] = recv.process(Message::fromCAN(can.at(0)));
     EXPECT_EQ(Receiver::State::PROCESSED, s0);
 
-    auto[s1, m1] = recv.process(Message::fromCAN(can.at(1)));
+    auto [s1, m1] = recv.process(Message::fromCAN(can.at(1)));
     EXPECT_EQ(Receiver::State::PROCESSED, s1);
 
-    auto[s2, m2] = recv.process(Message::fromCAN(can.at(2)));
+    auto [s2, m2] = recv.process(Message::fromCAN(can.at(2)));
     EXPECT_EQ(Receiver::State::COMPLETE, s2);
     ASSERT_EQ(19, m2.size);
     assertEqual("first1second2third3", m2.payload, 19);
@@ -150,7 +151,28 @@ TEST_F(MessageTest, it_increments_the_sequence_number)
 
     auto second = msg.toCAN();
     uint8_t second_seq_num = (first_seq_num + 1) % 8;
-    for(auto const& can_msg : second) {
+    for (auto const& can_msg : second) {
         EXPECT_EQ(second_seq_num, can_msg.data[0] >> 5);
+    }
+}
+
+TEST_F(MessageTest, it_thread_safely_generates_fast_packet_sequence_numbers)
+{
+    ASSERT_NE(Message::fastPacketSequenceNumber(), Message::fastPacketSequenceNumber());
+
+    std::vector<std::thread> threads(8);
+    std::array<uint8_t, 8> seq;
+    for (std::size_t n = 0; n < 13; n++) {
+        seq = {0, 0, 0, 0, 0, 0, 0, 0};
+        for (std::size_t t = 0; t < 8; t++) {
+            threads[t] =
+                std::thread([&seq]() { seq[Message::fastPacketSequenceNumber()]++; });
+        }
+        for (auto& thread : threads) {
+            thread.join();
+        }
+        for (uint8_t s : seq) {
+            EXPECT_EQ(1, s);
+        }
     }
 }

--- a/test/test_Message.cpp
+++ b/test/test_Message.cpp
@@ -54,7 +54,8 @@ TEST_F(MessageTest, it_creates_a_CAN_id_from_a_message_in_PDU1) {
     msg.destination = 0x52;
     msg.source = 0x3d;
     auto can = msg.toCAN();
-    ASSERT_EQ(0x1CEC523D | canbus::FLAG_EXTENDED_FRAME, can.can_id);
+    ASSERT_EQ(1, can.size());
+    ASSERT_EQ(0x1CEC523D | canbus::FLAG_EXTENDED_FRAME, can.at(0).can_id);
 }
 
 TEST_F(MessageTest, it_creates_a_CAN_id_from_a_message_in_PDU2) {
@@ -64,7 +65,8 @@ TEST_F(MessageTest, it_creates_a_CAN_id_from_a_message_in_PDU2) {
     msg.destination = 0xff;
     msg.source = 238;
     auto can = msg.toCAN();
-    ASSERT_EQ(0xFFE6CEE | canbus::FLAG_EXTENDED_FRAME, can.can_id);
+    ASSERT_EQ(1, can.size());
+    ASSERT_EQ(0xFFE6CEE | canbus::FLAG_EXTENDED_FRAME, can.at(0).can_id);
 }
 
 TEST_F(MessageTest, it_copies_the_package_time_data_and_length_to_the_CAN_frame) {
@@ -74,7 +76,9 @@ TEST_F(MessageTest, it_copies_the_package_time_data_and_length_to_the_CAN_frame)
     uint8_t data[5] = { 1, 2, 3, 4, 5 };
     memcpy(msg.payload, data, 5);
 
-    canbus::Message can = msg.toCAN();
+    std::vector<canbus::Message> to_can = msg.toCAN();
+    ASSERT_EQ(1, to_can.size());
+    auto const& can = to_can.at(0);
     ASSERT_EQ(base::Time::fromMilliseconds(1000), can.time);
     ASSERT_EQ(5, can.size);
     for (int i = 0; i < 5; ++i) {

--- a/test/test_Message.cpp
+++ b/test/test_Message.cpp
@@ -1,9 +1,16 @@
 #include <gtest/gtest.h>
 #include <nmea2000/Message.hpp>
+#include <nmea2000/Receiver.hpp>
 
 using namespace nmea2000;
 
 struct MessageTest : public ::testing::Test {
+    void assertEqual(char const* expected, uint8_t const* actual, std::size_t n)
+    {
+        for (std::size_t i = 0; i < n; i++) {
+            EXPECT_EQ(expected[i], actual[i]);
+        }
+    }
 };
 
 TEST_F(MessageTest, it_initializes_a_Message_from_a_CAN_frame_in_PDU1) {
@@ -83,5 +90,67 @@ TEST_F(MessageTest, it_copies_the_package_time_data_and_length_to_the_CAN_frame)
     ASSERT_EQ(5, can.size);
     for (int i = 0; i < 5; ++i) {
         ASSERT_EQ(i + 1, can.data[i]);
+    }
+}
+
+TEST_F(MessageTest, it_produces_fast_packet_messages)
+{
+    Message msg;
+    msg.pgn = 0xf123;
+
+    uint8_t payload[] = "first1second2third3";
+    msg.size = sizeof(payload) - 1; // -1 -> do not copy '/0'
+    std::copy((char*)&payload, (char*)&payload + msg.size, msg.payload);
+
+    auto can = msg.toCAN();
+    ASSERT_EQ(3, can.size());
+    EXPECT_EQ(19, can.at(0).data[1]);
+
+    ASSERT_EQ(8, can.at(0).size);
+    EXPECT_EQ(0, can.at(0).data[0] & 0x1f);
+    assertEqual("first1", &(can.at(0).data[2]), 6);
+
+    ASSERT_EQ(8, can.at(1).size);
+    EXPECT_EQ(1, can.at(1).data[0] & 0x1f);
+    assertEqual("second2", &(can.at(1).data[1]), 7);
+
+    ASSERT_EQ(7, can.at(2).size);
+    EXPECT_EQ(2, can.at(2).data[0] & 0x1f);
+    assertEqual("third3", &(can.at(2).data[1]), 6);
+
+    PGNLibrary lib({
+        {0xf123, msg.size}
+    });
+
+    Receiver recv(lib);
+    auto[s0, m0] = recv.process(Message::fromCAN(can.at(0)));
+    EXPECT_EQ(Receiver::State::PROCESSED, s0);
+
+    auto[s1, m1] = recv.process(Message::fromCAN(can.at(1)));
+    EXPECT_EQ(Receiver::State::PROCESSED, s1);
+
+    auto[s2, m2] = recv.process(Message::fromCAN(can.at(2)));
+    EXPECT_EQ(Receiver::State::COMPLETE, s2);
+    ASSERT_EQ(19, m2.size);
+    assertEqual("first1second2third3", m2.payload, 19);
+}
+
+TEST_F(MessageTest, it_increments_the_sequence_number)
+{
+    Message msg;
+
+    uint8_t payload[] = "first1second2third3";
+    msg.size = sizeof(payload) - 1; // -1 -> do not copy '/0'
+    std::copy((char*)&payload, (char*)&payload + msg.size, msg.payload);
+
+    auto first = msg.toCAN();
+    EXPECT_EQ(first.at(0).data[0] >> 5, first.at(1).data[0] >> 5);
+    EXPECT_EQ(first.at(1).data[0] >> 5, first.at(2).data[0] >> 5);
+    uint8_t first_seq_num = first.at(0).data[0] >> 5;
+
+    auto second = msg.toCAN();
+    uint8_t second_seq_num = (first_seq_num + 1) % 8;
+    for(auto const& can_msg : second) {
+        EXPECT_EQ(second_seq_num, can_msg.data[0] >> 5);
     }
 }


### PR DESCRIPTION
<!-- [sc-89292] -->
Depends on:
- [ ] https://github.com/tidewise/drivers-orogen-nmea2000/pull/13


### What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->

Add support for nmea2000 fast packet format. When the message payload size is greater than 8 bytes, it is decomposed in multiple messages. 
Each "sub message" payload starts with a byte in the format (_seq_num | frame_count_), seq_num size is 3 bits and frame_count is 5 bits. Frame count starts at 0 and is incremented for each sub message. The second byte of the very first message contains the size of the overall message, therefore the first message carries only 6 bytes of payload. The subsequent messages carry 7 bytes of payload (since the first byte is occupied by then _seq_num | frame_count_ byte)