### PR TITLE
chore: allow injection of pgn libraries at can interface

### DIFF
--- a/src/Adapters.cpp
+++ b/src/Adapters.cpp
@@ -30,6 +30,13 @@ CAN::CAN(std::string const& name, std::string const& type)
     , m_receiver(m_library) {
 }
 
+CAN::CAN(std::string const& name, PGNLibrary const& library, std::string const& type)
+    : m_driver{canbus::openCanDevice(name, type)}
+    , m_library{library}
+    , m_receiver(m_library)
+{
+}
+
 CAN::~CAN() {
     m_driver->close();
     delete m_driver;

--- a/src/Adapters.cpp
+++ b/src/Adapters.cpp
@@ -1,7 +1,6 @@
-#include <nmea2000/Adapters.hpp>
-#include <nmea2000/ActisenseDriver.hpp>
 #include <canbus/Driver.hpp>
 #include <iostream>
+#include <nmea2000/Adapters.hpp>
 
 using namespace base;
 using namespace nmea2000::adapters;
@@ -33,13 +32,12 @@ CAN::CAN(std::string const& name, std::string const& type)
 CAN::CAN(std::string const& name, PGNLibrary const& library, std::string const& type)
     : m_driver{canbus::openCanDevice(name, type)}
     , m_library{library}
-    , m_receiver(m_library)
+    , m_receiver{m_library}
 {
 }
 
 CAN::~CAN() {
     m_driver->close();
-    delete m_driver;
 }
 
 void CAN::writeMessage(Message const& message) {
@@ -96,7 +94,6 @@ Actisense::Actisense(std::string const& uri)
 
 Actisense::~Actisense() {
     m_driver->close();
-    delete m_driver;
 }
 
 void Actisense::writeMessage(Message const& message) {

--- a/src/Adapters.hpp
+++ b/src/Adapters.hpp
@@ -1,18 +1,18 @@
 #ifndef NMEA2000_ADAPTERS_HPP
 #define NMEA2000_ADAPTERS_HPP
 
+#include "ActisenseDriver.hpp"
+#include <canbus/Driver.hpp>
 #include <nmea2000/Message.hpp>
 #include <nmea2000/PGNLibrary.hpp>
 #include <nmea2000/Receiver.hpp>
-#include <canbus/Driver.hpp>
+#include <memory>
 
 namespace canbus {
     class Driver;
 }
 
 namespace nmea2000 {
-    class ActisenseDriver;
-
     /**
      * Ready-to-use classes for NMEA2000 access
      *
@@ -46,7 +46,7 @@ namespace nmea2000 {
 
         /** CAN interface */
         class CAN : public Interface {
-            canbus::Driver* m_driver = nullptr;
+            std::unique_ptr<canbus::Driver> m_driver;
             PGNLibrary m_library;
             Receiver m_receiver;
 
@@ -70,7 +70,7 @@ namespace nmea2000 {
 
         /** CAN interface */
         class Actisense : public Interface {
-            ActisenseDriver* m_driver = nullptr;
+            std::unique_ptr<ActisenseDriver> m_driver;
 
         public:
             /** Open an Actisense interface

--- a/src/Adapters.hpp
+++ b/src/Adapters.hpp
@@ -59,6 +59,9 @@ namespace nmea2000 {
              *      for more information
              */
             CAN(std::string const& name, std::string const& type = "socket");
+            CAN(std::string const& name,
+                PGNLibrary const& library,
+                std::string const& type = "socket");
             ~CAN();
 
             void writeMessage(Message const& msg);

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -31,12 +31,12 @@ int main(int argc, char** argv)
     string uri = argv[2];
     string cmd = argv[3];
 
-    adapters::Interface* interface = nullptr;
+    std::unique_ptr<adapters::Interface> interface ;
     if (type == "can") {
-        interface = new adapters::CAN(uri, "socket");
+        interface = std::make_unique<adapters::CAN>(uri, "socket");
     }
     else if (type == "actisense") {
-        interface = new adapters::Actisense(uri);
+        interface = std::make_unique<adapters::Actisense>(uri);
     }
     else {
         cerr << "unknown connection type '" << type << "'\n\n";

--- a/src/PGNLibrary.hpp
+++ b/src/PGNLibrary.hpp
@@ -2,6 +2,7 @@
 #define NMEA2000_PGNLIBRARY_HPP
 
 #include <map>
+#include <vector>
 #include <nmea2000/PGNInfo.hpp>
 
 namespace nmea2000 {


### PR DESCRIPTION
<!--
Depends on:
- [ ]
[sc-89292]
-->
### What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->

This PR makes it possible to create an `adapters::CAN` with a PGNLibrary other than the default (the first commit). The other commits are small improvements that we could live without, but since I am touching the code I've decided to make it a little better 